### PR TITLE
Add in CircleCI Support

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,9 @@
+machine:
+  xcode:
+    version: "8.1"
+general:
+  artifacts:
+    - artifacts
+test:
+  override:
+	 - bundle exec fastlane run_tests


### PR DESCRIPTION
Adds in the `circle.yml` file that will allow for the configuration of the CI server. Right
now we only need to test the main `Spruce` project. No need for any building of ipa's.

Fix #16 