### PR TITLE
Add iPad support to example app

### DIFF
--- a/Example/Spruce.xcodeproj/project.pbxproj
+++ b/Example/Spruce.xcodeproj/project.pbxproj
@@ -588,6 +588,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.willowtree.Spruce-Example";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 3.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
 		};
@@ -604,6 +605,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.willowtree.Spruce-Example";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 3.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
 		};


### PR DESCRIPTION
Currently we just want the iPad app to expand to fit the full screen. Simply needed to say that the app was universal and everything just worked.

Fix Issue: #52 