### PR TITLE
Fix warnings caused by newer versions of Swift.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Change Log
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.0.1] - 2017-07-12
+### Changed
+- Update Pi constants to `Double.pi` equivalents 
+- Update `RandomSortFunction` to Swift 4 syntax
+
 ## [1.0.0] - 2017-03-10
 ### Added
 - Initial release of Spruce

--- a/Sources/Classes/Animations/DefaultAnimations.swift
+++ b/Sources/Classes/Animations/DefaultAnimations.swift
@@ -243,11 +243,11 @@ public enum StockAnimation {
             case .spin(let size):
                 switch size {
                 case .slightly:
-                    return CGFloat(M_PI_4)
+                    return CGFloat(Double.pi / 4)
                 case .moderately:
-                    return CGFloat(M_PI_2)
+                    return CGFloat(Double.pi / 2)
                 case .severely:
-                    return CGFloat(M_PI)
+                    return CGFloat(Double.pi)
                 case .toAngle(let value):
                     return value
                 }

--- a/Sources/Classes/Sort Functions/RandomSortFunction.swift
+++ b/Sources/Classes/Sort Functions/RandomSortFunction.swift
@@ -52,7 +52,7 @@ public struct RandomSortFunction: SortFunction {
 
 // Array Shuffle:
 // http://stackoverflow.com/questions/24026510/how-do-i-shuffle-an-array-in-swift
-extension MutableCollection where Indices.Iterator.Element == Index {
+extension MutableCollection {
     /// Shuffles the contents of this collection.
     mutating func shuffle() {
         let c = count
@@ -62,7 +62,7 @@ extension MutableCollection where Indices.Iterator.Element == Index {
             let d: IndexDistance = numericCast(arc4random_uniform(numericCast(unshuffledCount)))
             guard d != 0 else { continue }
             let i = index(firstUnshuffled, offsetBy: d)
-            swap(&self[firstUnshuffled], &self[i])
+            swapAt(firstUnshuffled, i)
         }
     }
 }


### PR DESCRIPTION
Probably want to wait on this until Swift 4 is fully released.